### PR TITLE
fix: 00 after POW typos

### DIFF
--- a/audit_log/query_counts.sql
+++ b/audit_log/query_counts.sql
@@ -72,7 +72,7 @@ WITH
 SELECT
   query,
   queryCount,
-  ROUND(SAFE_DIVIDE(totalBytesBilled, POW(1024, 3)00) * 5, 2) AS onDemandCost,
+  ROUND(SAFE_DIVIDE(totalBytesBilled, POW(1024, 3)) * 5, 2) AS onDemandCost,
   ROUND(COALESCE(totalBytesBilled, 0), 2) AS totalBytesBilled,
   ROUND(COALESCE(totalBytesBilled, 0) / POW(1024, 2), 2) AS totalMegabytesBilled,
   ROUND(COALESCE(totalBytesBilled, 0) / POW(1024, 3), 2) AS totalGigabytesBilled,

--- a/audit_log/top_billed_queries.sql
+++ b/audit_log/top_billed_queries.sql
@@ -12,7 +12,7 @@ SELECT
     protopayload_auditlog.servicedata_v1_bigquery.jobCompletedEvent.job.jobStatistics.startTime,
     protopayload_auditlog.servicedata_v1_bigquery.jobCompletedEvent.job.jobStatistics.endTime,
     ROUND(SAFE_DIVIDE(COALESCE(protopayload_auditlog.servicedata_v1_bigquery.jobCompletedEvent.job.jobStatistics.totalBilledBytes,
-            0), POW(1024, 3)00) * 5, 2) AS onDemandCost,
+            0), POW(1024, 3)) * 5, 2) AS onDemandCost,
     ROUND(COALESCE(protopayload_auditlog.servicedata_v1_bigquery.jobCompletedEvent.job.jobStatistics.totalBilledBytes,
         0), 2) AS totalBytesBilled,
     ROUND(COALESCE(protopayload_auditlog.servicedata_v1_bigquery.jobCompletedEvent.job.jobStatistics.totalBilledBytes,

--- a/audit_log/top_cost_user_by_region_and_project.sql
+++ b/audit_log/top_cost_user_by_region_and_project.sql
@@ -11,7 +11,7 @@ WITH src AS (
         protopayload_auditlog.servicedata_v1_bigquery.jobCompletedEvent.job.jobStatistics.startTime,
         protopayload_auditlog.servicedata_v1_bigquery.jobCompletedEvent.job.jobStatistics.endTime,
         protopayload_auditlog.servicedata_v1_bigquery.jobCompletedEvent.job.jobStatistics.totalBilledBytes,
-        ROUND(SAFE_DIVIDE(protopayload_auditlog.servicedata_v1_bigquery.jobCompletedEvent.job.jobStatistics.totalBilledBytes, POW(1024, 3)00) * 5, 2) AS onDemandCost,
+        ROUND(SAFE_DIVIDE(protopayload_auditlog.servicedata_v1_bigquery.jobCompletedEvent.job.jobStatistics.totalBilledBytes, POW(1024, 3)) * 5, 2) AS onDemandCost,
         protopayload_auditlog.servicedata_v1_bigquery.jobCompletedEvent.job.jobStatistics.totalSlotMs,
         TIMESTAMP_DIFF(protopayload_auditlog.servicedata_v1_bigquery.jobCompletedEvent.job.jobStatistics.endTime,
                        protopayload_auditlog.servicedata_v1_bigquery.jobCompletedEvent.job.jobStatistics.startTime,


### PR DESCRIPTION
Fixes 3 similar typos in which a couple of 0's are added after a POW function.