### PR TITLE
Removed self-join that produces excessive results

### DIFF
--- a/audit_log/query_counts.sql
+++ b/audit_log/query_counts.sql
@@ -32,13 +32,10 @@ WITH
     _rnk = 1),
   hashedQueries AS (
     SELECT
-      src1.query AS query,
-      src1.hashed AS hashed
+      query,
+      hashed
     FROM
-      src AS src1,
-      src AS src2
-    WHERE
-      src1.hashed = src2.hashed ),
+      src ),
   pricedQueries AS (
     SELECT
       hashed,

--- a/audit_log/query_counts_general.sql
+++ b/audit_log/query_counts_general.sql
@@ -31,13 +31,10 @@ WITH
     _rnk = 1),
   hashedQueries AS (
     SELECT
-      src1.query AS query,
-      src1.hashed AS hashed
+      query,
+      hashed
     FROM
-      src AS src1,
-      src AS src2
-    WHERE
-      src1.hashed = src2.hashed ),
+      src ),
   pricedQueries AS (
     SELECT
       hashed,

--- a/audit_log/top_costly_queries.sql
+++ b/audit_log/top_costly_queries.sql
@@ -34,16 +34,12 @@ WITH
     _rnk = 1),
   hashedQueries AS (
     SELECT
-      src1.query AS query,
-      src1.hashed AS hashed,
-      SUM(src1.totalBilledBytes) AS totalBytesBilled,
-      COUNT(src1.hashed) AS queryCount
+      query AS query,
+      hashed AS hashed,
+      SUM(totalBilledBytes) AS totalBytesBilled,
+      COUNT(*) AS queryCount
     FROM
-      jobsDeduplicated AS src1,
-      jobsDeduplicated AS src2
-    WHERE
-      src1.hashed = src2.hashed
-      AND src1.jobId <> src2.jobId
+      jobsDeduplicated
     GROUP BY
       hashed,
       query

--- a/audit_log/top_costly_queries_general.sql
+++ b/audit_log/top_costly_queries_general.sql
@@ -33,16 +33,12 @@ WITH
     _rnk = 1),
   hashedQueries AS (
     SELECT
-      src1.query AS query,
-      src1.hashed AS hashed,
-      SUM(src1.totalBilledBytes) AS totalBytesBilled,
-      COUNT(src1.hashed) AS queryCount
+      query,
+      hashed,
+      SUM(totalBilledBytes) AS totalBytesBilled,
+      COUNT(*) AS queryCount
     FROM
-      jobsDeduplicated AS src1,
-      jobsDeduplicated AS src2
-    WHERE
-      src1.hashed = src2.hashed
-      AND src1.jobId <> src2.jobId
+      jobsDeduplicated
     GROUP BY
       hashed,
       query

--- a/information_schema/query_counts.sql
+++ b/information_schema/query_counts.sql
@@ -28,13 +28,10 @@ WITH
         _rnk = 1 ),
   hashedQueries AS (
     SELECT
-      src1.query AS query,
-      src1.hashed AS hashed
+      query,
+      hashed
     FROM
-      jobsDeduplicated AS src1,
-      jobsDeduplicated AS src2
-    WHERE
-      src1.hashed = src2.hashed ),
+      jobsDeduplicated ),
   pricedQueries AS (
     SELECT
       hashed,

--- a/information_schema/top_costly_queries.sql
+++ b/information_schema/top_costly_queries.sql
@@ -30,15 +30,12 @@ BEGIN
     ),
     hashedQueries AS (
         SELECT
-          src1.query AS query,
-          src1.hashed AS hashed,
-          SUM(src1.totalBytesBilled) AS totalBytesBilled,
-          COUNT(src1.hashed) AS queryCount
+          query,
+          hashed,
+          SUM(totalBytesBilled) AS totalBytesBilled,
+          COUNT(*) AS queryCount
         FROM
-          jobsDeduplicated AS src1, jobsDeduplicated AS src2
-        WHERE
-          src1.hashed = src2.hashed AND
-          src1.jobId <> src2.jobId
+          jobsDeduplicated
         GROUP BY
           hashed, query
     )


### PR DESCRIPTION
We encountered the problem that information requests do not reflect the reality and produce enormous numbers.
There is already an issue created by other users https://github.com/doitintl/bigquery-optimization-queries/issues/12
This PR fixes the problem by removing odd cartesian self-join in intermediate query.